### PR TITLE
Bump Version to 2026.03.0-212

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = positron-ide-devel-bin
 	pkgdesc = A next-generation data science IDE. Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages.
-	pkgver = 2026.02.1.5
+	pkgver = 2026.03.0.212
 	pkgrel = 1
 	url = https://github.com/posit-dev/positron
 	arch = x86_64
@@ -89,9 +89,9 @@ pkgbase = positron-ide-devel-bin
 	provides = positron
 	conflicts = positron-bin
 	options = !debug
-	source_x86_64 = https://cdn.posit.co/positron/releases/deb/x86_64/Positron-2026.02.1-5-x64.deb
-	sha256sums_x86_64 = 693573242b0c0115dc89ab06bfb97fb3215bdd5f35222ea0565eac06b10f1733
-	source_aarch64 = https://cdn.posit.co/positron/releases/deb/arm64/Positron-2026.02.1-5-arm64.deb
-	sha256sums_aarch64 = 016e23b9e16d76fae62009be779fea8f2562692a6e7b9d5d6f2538358b37bda1
+	source_x86_64 = https://cdn.posit.co/positron/releases/deb/x86_64/Positron-2026.03.0-212-x64.deb
+	sha256sums_x86_64 = dfbb96c74f407057caaec7da76ce04f35bc6d805f9ef91fb1a83f2e8079c89ff
+	source_aarch64 = https://cdn.posit.co/positron/releases/deb/arm64/Positron-2026.03.0-212-arm64.deb
+	sha256sums_aarch64 = 9a2171b0a8307d792d6f4f8c1fc81f6105e8e0e7f7ebd578198fe94b76185cfa
 
 pkgname = positron-ide-devel-bin

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = positron-ide-devel-bin
 	pkgdesc = A next-generation data science IDE. Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages.
-	pkgver = 2026.01.0.147
+	pkgver = 2026.02.0.139
 	pkgrel = 1
 	url = https://github.com/posit-dev/positron
 	arch = x86_64
@@ -89,9 +89,9 @@ pkgbase = positron-ide-devel-bin
 	provides = positron
 	conflicts = positron-bin
 	options = !debug
-	source_x86_64 = https://cdn.posit.co/positron/releases/deb/x86_64/Positron-2026.01.0-147-x64.deb
-	sha256sums_x86_64 = 78927ea9c7e3db20ca1b6b88b5db60a13e7e55a797736ff27ca3f94de4ae93bd
-	source_aarch64 = https://cdn.posit.co/positron/releases/deb/arm64/Positron-2026.01.0-147-arm64.deb
-	sha256sums_aarch64 = bbc26b2254942329d9959d28f99f305a5b480f3f3fbead02ca73e22d267a335e
+	source_x86_64 = https://cdn.posit.co/positron/releases/deb/x86_64/Positron-2026.02.0-139-x64.deb
+	sha256sums_x86_64 = 9639541d91cfa41fc4907a46b34c1df93f924f105a1ed57eef99106dbf56560d
+	source_aarch64 = https://cdn.posit.co/positron/releases/deb/arm64/Positron-2026.02.0-139-arm64.deb
+	sha256sums_aarch64 = 47a5ed5c9026afd7b9872d65609f6b03d5d83f791a5485b19f8f56641c6a1a93
 
 pkgname = positron-ide-devel-bin

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = positron-ide-devel-bin
 	pkgdesc = A next-generation data science IDE. Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages.
-	pkgver = 2026.02.0.139
+	pkgver = 2026.02.1.5
 	pkgrel = 1
 	url = https://github.com/posit-dev/positron
 	arch = x86_64
@@ -89,9 +89,9 @@ pkgbase = positron-ide-devel-bin
 	provides = positron
 	conflicts = positron-bin
 	options = !debug
-	source_x86_64 = https://cdn.posit.co/positron/releases/deb/x86_64/Positron-2026.02.0-139-x64.deb
-	sha256sums_x86_64 = 9639541d91cfa41fc4907a46b34c1df93f924f105a1ed57eef99106dbf56560d
-	source_aarch64 = https://cdn.posit.co/positron/releases/deb/arm64/Positron-2026.02.0-139-arm64.deb
-	sha256sums_aarch64 = 47a5ed5c9026afd7b9872d65609f6b03d5d83f791a5485b19f8f56641c6a1a93
+	source_x86_64 = https://cdn.posit.co/positron/releases/deb/x86_64/Positron-2026.02.1-5-x64.deb
+	sha256sums_x86_64 = 693573242b0c0115dc89ab06bfb97fb3215bdd5f35222ea0565eac06b10f1733
+	source_aarch64 = https://cdn.posit.co/positron/releases/deb/arm64/Positron-2026.02.1-5-arm64.deb
+	sha256sums_aarch64 = 016e23b9e16d76fae62009be779fea8f2562692a6e7b9d5d6f2538358b37bda1
 
 pkgname = positron-ide-devel-bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.deb
+pkg
 positron-ide-*
 src
-pkg

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#276bbc",
+    "activityBar.background": "#276bbc",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#6a163c",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#276bbc",
+    "statusBar.background": "#1e5392",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#276bbc",
+    "statusBarItem.remoteBackground": "#1e5392",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#1e5392",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#1e539299",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.color": "#1e5392",
+  "cSpell.words": [
+    "Leothelion",
+    "makepkg",
+    "PKGBUILD",
+    "vecchio"
+  ]
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=positron-ide-devel-bin
 _pkgname=positron-ide
-pkgver=2026.02.1.5
-pkgver_url=2026.02.1-5
+pkgver=2026.03.0.212
+pkgver_url=2026.03.0-212
 pkgrel=1
 pkgdesc="A next-generation data science IDE. Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages."
 arch=('x86_64' 'aarch64')
@@ -113,8 +113,8 @@ provides=("positron")
 conflicts=("positron-bin")
 source_x86_64=("${posit_url}/x86_64/Positron-${pkgver_url}-x64.deb")
 source_aarch64=("${posit_url}/arm64/Positron-${pkgver_url}-arm64.deb")
-sha256sums_x86_64=('693573242b0c0115dc89ab06bfb97fb3215bdd5f35222ea0565eac06b10f1733')
-sha256sums_aarch64=('016e23b9e16d76fae62009be779fea8f2562692a6e7b9d5d6f2538358b37bda1')
+sha256sums_x86_64=('dfbb96c74f407057caaec7da76ce04f35bc6d805f9ef91fb1a83f2e8079c89ff')
+sha256sums_aarch64=('9a2171b0a8307d792d6f4f8c1fc81f6105e8e0e7f7ebd578198fe94b76185cfa')
 
 package(){
     shopt -s extglob

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=positron-ide-devel-bin
 _pkgname=positron-ide
-pkgver=2026.02.0.139
-pkgver_url=2026.02.0-139
+pkgver=2026.02.1.5
+pkgver_url=2026.02.1-5
 pkgrel=1
 pkgdesc="A next-generation data science IDE. Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages."
 arch=('x86_64' 'aarch64')
@@ -113,8 +113,8 @@ provides=("positron")
 conflicts=("positron-bin")
 source_x86_64=("${posit_url}/x86_64/Positron-${pkgver_url}-x64.deb")
 source_aarch64=("${posit_url}/arm64/Positron-${pkgver_url}-arm64.deb")
-sha256sums_x86_64=('9639541d91cfa41fc4907a46b34c1df93f924f105a1ed57eef99106dbf56560d')
-sha256sums_aarch64=('47a5ed5c9026afd7b9872d65609f6b03d5d83f791a5485b19f8f56641c6a1a93')
+sha256sums_x86_64=('693573242b0c0115dc89ab06bfb97fb3215bdd5f35222ea0565eac06b10f1733')
+sha256sums_aarch64=('016e23b9e16d76fae62009be779fea8f2562692a6e7b9d5d6f2538358b37bda1')
 
 package(){
     shopt -s extglob

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=positron-ide-devel-bin
 _pkgname=positron-ide
-pkgver=2026.01.0.147
-pkgver_url=2026.01.0-147
+pkgver=2026.02.0.139
+pkgver_url=2026.02.0-139
 pkgrel=1
 pkgdesc="A next-generation data science IDE. Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages."
 arch=('x86_64' 'aarch64')
@@ -30,7 +30,7 @@ depends=(
     'gtk3'
     'gtk4'
     # 'nspr' # nss
-    'nss' 
+    'nss'
     'pango'
     # 'gcc-libs' # mesa
     'systemd-libs' # for udev1
@@ -111,10 +111,10 @@ optdepends=(
 )
 provides=("positron")
 conflicts=("positron-bin")
-source_aarch64=("${posit_url}/arm64/Positron-${pkgver_url}-arm64.deb")
 source_x86_64=("${posit_url}/x86_64/Positron-${pkgver_url}-x64.deb")
-sha256sums_aarch64=('bbc26b2254942329d9959d28f99f305a5b480f3f3fbead02ca73e22d267a335e')
-sha256sums_x86_64=('78927ea9c7e3db20ca1b6b88b5db60a13e7e55a797736ff27ca3f94de4ae93bd')
+source_aarch64=("${posit_url}/arm64/Positron-${pkgver_url}-arm64.deb")
+sha256sums_x86_64=('9639541d91cfa41fc4907a46b34c1df93f924f105a1ed57eef99106dbf56560d')
+sha256sums_aarch64=('47a5ed5c9026afd7b9872d65609f6b03d5d83f791a5485b19f8f56641c6a1a93')
 
 package(){
     shopt -s extglob

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ To build and install the `positron-ide-devel-bin` package, follow these steps:
 
 This command will download the necessary files, build the package, and install it on your system.
 
-## Known Issues
-
-### GitHub Copilot
-
-GitHub Copilot may fail to authenticate on fresh installations of Positron IDE on Arch Linux. If you encounter issues, sign out of GitHub Copilot and sign back in to resolve the problem.
-
 ## License
 
 [![License: GPLv3](https://img.shields.io/badge/license-GPLv3-bd0000.svg)](https://www.gnu.org/licenses/gpl-3.0)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# positron-ide-devel-bin
+
+<!-- badges: start -->
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![GPLv3 License Badge](https://img.shields.io/badge/license-GPLv3-bd0000.png)](https://www.gnu.org/licenses/gpl-3.0)
+<!-- badges: end -->
+
+## Overview
+
+This repository contains a [PKGBUILD](https://wiki.archlinux.org/title/PKGBUILD) script for building and installing the [`positron-ide-devel-bin`](https://aur.archlinux.org/packages/positron-ide-devel-bin) package from the Arch User Repository ([AUR](https://aur.archlinux.org/)).
+
+## Usage
+
+To build and install the `positron-ide-devel-bin` package, follow these steps:
+
+1. **Clone the Repository**: Open your terminal and run the following command to clone this repository:
+
+```bash
+  git clone https://github.com/ponte-vecchio/positron
+```
+
+2. **Navigate to the Directory**: Change into the cloned repository's directory:
+
+```bash
+  cd positron
+```
+
+3. **Build and Install the Package**: Use the `makepkg` command to build and install the package:
+
+```bash
+  makepkg -si
+```
+
+This command will download the necessary files, build the package, and install it on your system.
+
+## Known Issues
+
+### GitHub Copilot
+
+GitHub Copilot may fail to authenticate on fresh installations of Positron IDE on Arch Linux. If you encounter issues, sign out of GitHub Copilot and sign back in to resolve the problem.
+
+## License
+
+[![License: GPLv3](https://img.shields.io/badge/license-GPLv3-bd0000.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
+```text
+Copyright (C) 2026 Leothelion
+
+positron-ide-devel-bin is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+```


### PR DESCRIPTION
Hi there,

This PR bumps Positron to the latest version and adds a README file to the repository.

I've already tested it on my machine (x64).

Cheers!